### PR TITLE
Alle dependencies werden beim Starten installiert

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
     working_dir: /backend
     volumes:
       - ./backend:/backend
-    command: sh -c "npm install & npm start"
+    command: sh -c "npm install && npm start"
     depends_on:
       - db
   db:


### PR DESCRIPTION
Beim `command` des API-Containers fehlte ein zweites & und hat deshalb nur `npm start` ausgeführt.